### PR TITLE
A0-2231: Fix uneven gap between accounts on a list

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/AccountsTree.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/AccountsTree.tsx
@@ -63,7 +63,6 @@ function AccountsTree({
 export default styled(AccountsTree)`
     display: flex;
     flex-direction: column;
-    gap: 8px;
     
   .accountWichCheckbox {
     display: flex;


### PR DESCRIPTION
There were 2 _methods_ of adding gaps used simulatenously, cumulating the gap size: the bottom margin and the `gap`. The former is deeper-rooted in the components structure, so I'm ditching the latter.

![image](https://github.com/Cardinal-Cryptography/aleph-zero-signer/assets/6209244/03b8d57b-b84a-4257-a9a3-275005f7769b)
