### PR TITLE
A0-2400: Add PBKDF2 derivation of the key used for HMAC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,12 +12,14 @@ module.exports = {
   rules: {
     ...base.rules,
     // this seems very broken atm, false positives
-    '@typescript-eslint/unbound-method': 'off'
+    '@typescript-eslint/unbound-method': 'off',
+    'sort-keys': 'off',
   },
   overrides: [...base.overrides, {
     files: ['**/*.test.*', '**/*.stories.*'],
     rules: {
-      '@typescript-eslint/ban-ts-comment': 'off'
+      '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off'
     }
   }],
   extends: [...base.extends, 'plugin:storybook/recommended']

--- a/packages/extension-base/package.json
+++ b/packages/extension-base/package.json
@@ -36,7 +36,8 @@
     "@polkadot/util-crypto": "^12.1.2",
     "canonicalize": "^2.0.0",
     "eventemitter3": "^4.0.7",
-    "rxjs": "^7.8.0"
+    "rxjs": "^7.8.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@polkadot/extension-mocks": "^0.44.8"

--- a/packages/extension-base/src/utils/accountJsonIntegrity.test.ts
+++ b/packages/extension-base/src/utils/accountJsonIntegrity.test.ts
@@ -32,7 +32,7 @@ test('appends a signature', async () => {
     'signatureMaterial',
     {
       signature: expect.any(String),
-      salt: expect.any(String),
+      salt: expect.any(String)
     }
   );
 });

--- a/packages/extension-base/src/utils/accountJsonIntegrity.test.ts
+++ b/packages/extension-base/src/utils/accountJsonIntegrity.test.ts
@@ -23,15 +23,17 @@ const TEST_ACCOUNT_JSON = {
     whenCreated: 1683202623704
   }
 };
-const HMAC = 'N7PKhDrR3QbLhaDHDDvXdWLV5tU+CR1pHa2P1iI8Bv3gKAcGkQG7NwueQTAEgewbQHoI1g/BUPpt2ynJCTiuyg==';
 const password = 'password';
 
 test('appends a signature', async () => {
   const signedAccountJson = await signJson(TEST_ACCOUNT_JSON, password);
 
   expect(signedAccountJson).toHaveProperty(
-    'signature',
-    HMAC
+    'signatureMaterial',
+    {
+      signature: expect.any(String),
+      salt: expect.any(String),
+    }
   );
 });
 
@@ -69,7 +71,7 @@ test('verification fails if the signature is forged', async () => {
 
   const forgedAccountJson = {
     ...realSignedAccountJson,
-    signature: forgedSignedAccountJson.signature
+    signatureMaterial: forgedSignedAccountJson.signatureMaterial
   };
 
   expect(await isJsonAuthentic(forgedAccountJson, password)).toBeFalsy();

--- a/packages/extension-base/src/utils/accountJsonIntegrity.ts
+++ b/packages/extension-base/src/utils/accountJsonIntegrity.ts
@@ -14,7 +14,8 @@ const signatureSchema = z.object({
     signature: z.string(),
     salt: z.string()
   })
-})
+});
+
 type SignatureData = z.infer<typeof signatureSchema>
 
 const encoder = new TextEncoder();
@@ -27,7 +28,7 @@ const encoder = new TextEncoder();
 export const signJson = async <J extends object>(json: J, password: string): Promise<J & SignatureData> => {
   const canonicalJson = canonicalize(json);
 
-  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const salt = crypto.getRandomValues(new Uint8Array(16));
   const key = await generateKey(password, salt);
   const hmac = await crypto.subtle.sign(ALGO.name, key, encoder.encode(canonicalJson));
 
@@ -36,7 +37,7 @@ export const signJson = async <J extends object>(json: J, password: string): Pro
     signatureMaterial: {
       signature: bufferToBase64(hmac),
       salt: bufferToBase64(salt)
-    },
+    }
   };
 };
 
@@ -44,12 +45,15 @@ export const isJsonAuthentic = async (
   json: unknown,
   password: string
 ) => {
-  const validationResult = signatureSchema.passthrough().safeParse(json)
+  const validationResult = signatureSchema.passthrough().safeParse(json);
 
-  const isSignedJson = validationResult.success
-  if (!isSignedJson) return false;
+  const isSignedJson = validationResult.success;
 
-  const { signatureMaterial: { signature, salt }, ...accountJson } = validationResult.data;
+  if (!isSignedJson) {
+    return false;
+  }
+
+  const { signatureMaterial: { salt, signature }, ...accountJson } = validationResult.data;
 
   const canonicalJson = canonicalize(accountJson);
 
@@ -70,9 +74,9 @@ const generateKey = async (password: string, salt: Uint8Array) => {
     name: 'PBKDF2',
     salt,
     iterations: 210_000, // As per the recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
-    hash: 'SHA-512',
-  }, initialKeyMaterial, ALGO, false, ['sign', 'verify'])
-}
+    hash: 'SHA-512'
+  }, initialKeyMaterial, ALGO, false, ['sign', 'verify']);
+};
 
-const bufferToBase64 = (buffer: ArrayBufferLike) => self.btoa(String.fromCharCode(...new Uint8Array(buffer)))
-const base64ToBuffer = (base64: string) => Uint8Array.from(self.atob(base64), (c) => c.charCodeAt(0))
+const bufferToBase64 = (buffer: ArrayBufferLike) => self.btoa(String.fromCharCode(...new Uint8Array(buffer)));
+const base64ToBuffer = (base64: string) => Uint8Array.from(self.atob(base64), (c) => c.charCodeAt(0));

--- a/packages/extension-base/src/utils/accountJsonIntegrity.ts
+++ b/packages/extension-base/src/utils/accountJsonIntegrity.ts
@@ -2,11 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import canonicalize from 'canonicalize';
+import { z } from 'zod';
 
 const ALGO = {
   hash: { name: 'SHA-512' },
   name: 'HMAC'
 };
+
+const signatureSchema = z.object({
+  signatureMaterial: z.object({
+    signature: z.string(),
+    salt: z.string()
+  })
+})
+type SignatureData = z.infer<typeof signatureSchema>
 
 const encoder = new TextEncoder();
 
@@ -15,15 +24,19 @@ const encoder = new TextEncoder();
  * backward compatibility of the JSONs that have already been exported
  * and should be possible to be imported after these changes.
  */
-export const signJson = async <J extends object>(json: J, password: string): Promise<J & { signature: string }> => {
+export const signJson = async <J extends object>(json: J, password: string): Promise<J & SignatureData> => {
   const canonicalJson = canonicalize(json);
 
-  const key = await generateKey(password);
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+  const key = await generateKey(password, salt);
   const hmac = await crypto.subtle.sign(ALGO.name, key, encoder.encode(canonicalJson));
 
   return {
     ...json,
-    signature: self.btoa(String.fromCharCode(...new Uint8Array(hmac)))
+    signatureMaterial: {
+      signature: bufferToBase64(hmac),
+      salt: bufferToBase64(salt)
+    },
   };
 };
 
@@ -31,26 +44,35 @@ export const isJsonAuthentic = async (
   json: unknown,
   password: string
 ) => {
-  if (!isSignedJson(json)) {
-    return false;
-  }
+  const validationResult = signatureSchema.passthrough().safeParse(json)
 
-  const { signature, ...accountJson } = json;
+  const isSignedJson = validationResult.success
+  if (!isSignedJson) return false;
+
+  const { signatureMaterial: { signature, salt }, ...accountJson } = validationResult.data;
 
   const canonicalJson = canonicalize(accountJson);
 
-  const key = await generateKey(password);
+  const key = await generateKey(password, base64ToBuffer(salt));
 
   return crypto.subtle.verify(
     ALGO.name,
     key,
-    Uint8Array.from(self.atob(signature), (c) => c.charCodeAt(0)),
+    base64ToBuffer(signature),
     encoder.encode(canonicalJson)
   );
 };
 
-const generateKey = (password: string) =>
-  crypto.subtle.importKey('raw', encoder.encode(password), ALGO, false, ['sign', 'verify']);
+const generateKey = async (password: string, salt: Uint8Array) => {
+  const initialKeyMaterial = await crypto.subtle.importKey('raw', encoder.encode(password), 'PBKDF2', false, ['deriveBits', 'deriveKey']);
 
-const isSignedJson = (json: unknown): json is { signature: string } =>
-  typeof json === 'object' && json !== null && 'signature' in json;
+  return crypto.subtle.deriveKey({
+    name: 'PBKDF2',
+    salt,
+    iterations: 210_000, // As per the recommendation: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2
+    hash: 'SHA-512',
+  }, initialKeyMaterial, ALGO, false, ['sign', 'verify'])
+}
+
+const bufferToBase64 = (buffer: ArrayBufferLike) => self.btoa(String.fromCharCode(...new Uint8Array(buffer)))
+const base64ToBuffer = (base64: string) => Uint8Array.from(self.atob(base64), (c) => c.charCodeAt(0))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3196,6 +3196,7 @@ __metadata:
     canonicalize: ^2.0.0
     eventemitter3: ^4.0.7
     rxjs: ^7.8.0
+    zod: ^3.21.4
   languageName: unknown
   linkType: soft
 
@@ -21284,6 +21285,13 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.21.4":
+  version: 3.21.4
+  resolution: "zod@npm:3.21.4"
+  checksum: f185ba87342ff16f7a06686767c2b2a7af41110c7edf7c1974095d8db7a73792696bcb4a00853de0d2edeb34a5b2ea6a55871bc864227dace682a0a28de33e1f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Approved by Kudelski's](https://cardinalcryptography.slack.com/archives/C04UQHQ8J9M/p1684959636646009?thread_ts=1684849821.869139&cid=C04UQHQ8J9M) from security perspective.