### PR TITLE
A0-2233: Revert blur smoothing

### DIFF
--- a/packages/extension-ui/src/components/BottomWrapper.tsx
+++ b/packages/extension-ui/src/components/BottomWrapper.tsx
@@ -24,5 +24,4 @@ export default styled(BottomWrapper)`
   z-index: ${Z_INDEX.BOTTOM_WRAPPER};
   max-width: 375px;
   backdrop-filter: blur(10px);
-  mask-image: linear-gradient(to bottom, #0000 0, #000f 5px);
 `;


### PR DESCRIPTION
A regression has been found in which the blur smoothing has hidden the top border. Since the regression was found in views that seemed unrelated, an inquiry has been made about how the blur and the top border should behave, which showed that the current implementation does not reflect it at all. A more thorough investigation has been undertaken to find links between this small component and the rest of the app in order to fix that state. The results showed a complex network of cross-dependencies between multitude of components, including multi-level global styles overrides spreading across whole trees of components - a completely unmanageable state. An attempt has been made to put this to order by implementing visual regression tests, but this in turn revealed a plethora of other problems with unmaintainable styles and deprecated libraries versions. The conclusion was that it's impossible to fix the top border disappearing in presence of the mask without a major application refactor, hence undoing the mask in this commit.