### PR TITLE
A0-2236: Fix list item margins

### DIFF
--- a/packages/extension-ui/src/Popup/Accounts/Account.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/Account.tsx
@@ -183,6 +183,8 @@ function Account({
 
 export default styled(Account)(
   ({ theme, withCheckbox }: Props) => `
+  display: flex;
+  
   ${Address}:hover {
     background: ${withCheckbox ? theme.menuBackground : theme.menuBackground};
     ${withCheckbox ? ' cursor: pointer;' : ''}   
@@ -198,6 +200,7 @@ export default styled(Account)(
   }
 
   .address {
+    min-width: 0;
     display: flex;
     align-items: center;
     margin-bottom: 16px;

--- a/packages/extension-ui/src/Popup/Accounts/AccountsTree.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/AccountsTree.tsx
@@ -65,9 +65,6 @@ export default styled(AccountsTree)`
     flex-direction: column;
     
   .accountWichCheckbox {
-    display: flex;
-    align-items: center;
-
     & .address {
       flex: 1;
     }

--- a/packages/extension-ui/src/Popup/Accounts/NewAccount.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/NewAccount.tsx
@@ -149,6 +149,10 @@ export default withRouter(styled(NewAccount)`
     bottom: -8px !important;
   }
 
+  .accountSelection {
+    max-width: 100%;
+  }
+
   .content {
     margin-top: 8px;
     overflow-y: scroll;

--- a/packages/extension-ui/src/components/Address.tsx
+++ b/packages/extension-ui/src/components/Address.tsx
@@ -220,15 +220,12 @@ function Address({
                     <span>{parentNameSuri}</span>
                   </div>
                 </div>
-                <div className='name displaced'>
+                <div className='displaced'>
                   <Name />
                 </div>
               </>
             ) : (
-              <div
-                className='name'
-                data-field='name'
-              >
+              <div data-field='name'>
                 <Name />
               </div>
             )}
@@ -384,6 +381,7 @@ export default styled(Address)(
   }
 
   .identityIcon {
+    flex-shrink: 0;
     margin-left: 16px;
     margin-right: 14px;
     width: 50px;
@@ -395,11 +393,13 @@ export default styled(Address)(
   }
 
   .info {
-    max-width: 200px;
+    min-width: 0;
     border-radius: 8px;
   }
 
   .infoRow {
+    min-width: 0;
+    flex-grow: 1;
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
@@ -449,6 +449,7 @@ export default styled(Address)(
   }
 
   .name {
+    display: block;
     font-size: 16px;
     line-height: 125%;
     letter-spacing: 0.06em;
@@ -460,8 +461,8 @@ export default styled(Address)(
     width: 300px;
     white-space: nowrap;
     color: ${theme.textColor};
-    width: 190px;
     margin-right: 4px;
+    max-width: 100%;
   } 
 
     &.displaced {

--- a/packages/extension-ui/src/partials/AccountSelection.tsx
+++ b/packages/extension-ui/src/partials/AccountSelection.tsx
@@ -189,6 +189,7 @@ export default styled(AccountSelection)(
       
       ${Checkbox} {
         margin-left: 8px;
+        margin-right: 16px;
       }
     }
   }

--- a/packages/extension-ui/src/partials/NewAccountSelection.tsx
+++ b/packages/extension-ui/src/partials/NewAccountSelection.tsx
@@ -246,6 +246,11 @@ export default styled(NewAccountSelection)(
     }
     ${Account} {
       padding: 2px 4px;
+
+      ${Checkbox} {
+        margin-left: 8px;
+        margin-right: 16px;
+      }
     }
   }
 


### PR DESCRIPTION
Some of the list items' elements had fixed width in px which caused the items to overflow on views in which their ancestors did not have the exact perfect width for which it was designed. Fixing those elements required changes in several levels of ancestor elements, turning them into proper flex elements.