### PR TITLE
A0-2721: Fix tooltip shown under header steps

### DIFF
--- a/packages/extension-ui/src/partials/HeaderWithSteps.tsx
+++ b/packages/extension-ui/src/partials/HeaderWithSteps.tsx
@@ -37,7 +37,7 @@ export const Steps = styled.div`
   justify-content: center;
   gap: 8px;
   position: sticky;
-  z-index: ${Z_INDEX.HEADER};
+  z-index: ${Z_INDEX.HEADER_STEPS};
   top: 56px;
 
   :first-child {
@@ -49,12 +49,7 @@ export const Steps = styled.div`
   }
 `;
 
-function HeaderWithSteps({
-  step,
-  text,
-  total,
-  withBackArrow = false,
-}: Props): React.ReactElement<Props> {
+function HeaderWithSteps({ step, text, total, withBackArrow = false }: Props): React.ReactElement<Props> {
   return (
     <>
       <Header

--- a/packages/extension-ui/src/zindex.ts
+++ b/packages/extension-ui/src/zindex.ts
@@ -7,10 +7,13 @@ export const Z_INDEX = {
   ADD_ACCOUNT_FOREGROUND: 100,
   BOTTOM_WRAPPER: 100,
   DROPDOWN: 100,
-  HEADER: 100,
+  // Header have to have higher z-index than HEADER_STEPS.
+  // Otherwise help / settings tooltip hides under steps.
+  HEADER: 101,
+  HEADER_STEPS: 100,
   MENU: 2,
   SPLASH_HEADER: 105,
-  TOAST: 100,
+  TOAST: 102,
   TOOLTIP: 99,
   NEW_ACCOUNT_RIBBON: 99
 };


### PR DESCRIPTION
The branch name is misleading - it seem the links where already in place, but I fixed this small css issue:
![image](https://github.com/Cardinal-Cryptography/aleph-zero-signer/assets/35614528/1200ed3f-2c07-4d78-8a8a-73b519a87f94)
