### PR TITLE
A0-2812: Use the original port when listening for disconnect

### DIFF
--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -32,10 +32,10 @@ listenOnPort((getContentPort, getCurrentPort) => {
 
   // message and disconnect handlers
   getCurrentPort().onMessage.addListener((data: TransportRequestMessage<keyof RequestSignatures>) => handlers(data, getCurrentPort, getContentPort));
-  getCurrentPort().onDisconnect.addListener(() => {
+  getCurrentPort().onDisconnect.addListener((port) => {
     clearTimeout(timer);
 
-    console.log(`Disconnected from ${getCurrentPort().name}`);
+    console.log(`Disconnected from ${port.name}`);
   });
 });
 
@@ -56,7 +56,10 @@ function getActiveTabs () {
       request: { urls }
     };
 
-    const portGetterMock = () => ({ name: PORT_EXTENSION } as chrome.runtime.Port);
+    const portGetterMock = () => ({
+      name: PORT_EXTENSION,
+      postMessage: (param: any) => undefined, // eslint-disable-line
+    } as chrome.runtime.Port);
 
     // This invocation is only pretending to be handling a port connection message, so we're sending
     // a mock port getter as there are no ports involved.

--- a/packages/extension/src/listenOnPort.ts
+++ b/packages/extension/src/listenOnPort.ts
@@ -15,13 +15,13 @@ type GetContentPort = (tabId: number) => chrome.runtime.Port
 type GetCurrentPort = () => chrome.runtime.Port
 
 export default (cb: (getContentPort: GetContentPort, getCurrentPort: GetCurrentPort) => void) => {
-  const contentPorts: {
+  const contentPorts: Partial<{
     [tabId: string]: chrome.runtime.Port
-  } = {};
-  const extensionPorts: {
+  }> = {};
+  const extensionPorts: Partial<{
     // There is a special case in which the key is "undefined" representing the native extension popup
     [tabId: string]: chrome.runtime.Port
-  } = {};
+  }> = {};
 
   const getContentPort = (tabId: number) => {
     const port = contentPorts[tabId];
@@ -50,7 +50,15 @@ export default (cb: (getContentPort: GetContentPort, getCurrentPort: GetCurrentP
      * Not returning "port" directly in order to always return the fresh instance
      * of the port (i.e. with the same name).
      */
-    const getCurrentPort = () => portsMap[getPortTabAsString(port)];
+    const getCurrentPort = () => {
+      const currentPort = portsMap[getPortTabAsString(port)];
+
+      if (!currentPort) {
+        throw new Error('The current port is no longer connected.');
+      }
+
+      return port;
+    };
 
     cb(getContentPort, getCurrentPort);
   });


### PR DESCRIPTION
Bulletproofing a little bit more the mechanism of acquiring the currently connected port. It used to throw errors in one place upon port reconnect caused by the service worker going to sleep.