### PR TITLE
A0-2818: Fix data flow of the connected active tab information

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -518,12 +518,12 @@ export default class Extension {
     return this.#state.removeAuthRequest(requestId);
   }
 
-  private async updateCurrentTabs ({ urls }: RequestActiveTabsUrlUpdate) {
-    await this.#state.updateCurrentTabsUrl(urls);
+  private updateActiveTabUrl ({ url }: RequestActiveTabsUrlUpdate) {
+    this.#state.updateActiveTabUrl(url);
   }
 
-  private getConnectedTabsUrl () {
-    return this.#state.getConnectedTabsUrl();
+  private getConnectedActiveTabUrl () {
+    return this.#state.getConnectedActiveTabUrl();
   }
 
   // Weird thought, the eslint override is not needed in Tabs
@@ -600,11 +600,11 @@ export default class Extension {
       case 'pri(metadata.reject)':
         return this.metadataReject(request as RequestMetadataReject, getContentPort).then(respondImmediately);
 
-      case 'pri(activeTabsUrl.update)':
-        return this.updateCurrentTabs(request as RequestActiveTabsUrlUpdate).then(respondImmediately);
+      case 'pri(activeTabUrl.update)':
+        return respondImmediately(this.updateActiveTabUrl(request as RequestActiveTabsUrlUpdate));
 
       case 'pri(connectedTabsUrl.get)':
-        return respondImmediately(this.getConnectedTabsUrl());
+        return this.getConnectedActiveTabUrl().then(respondImmediately);
 
       case 'pri(derivation.create)':
         return respondImmediately(this.derivationCreate(request as RequestDeriveCreate));

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -6,7 +6,7 @@ import type { KeyringPair, KeyringPair$Json, KeyringPair$Meta } from '@polkadot/
 import type { Registry, SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types';
 import type { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
-import type { AccountJson, AllowedPath, MessageTypes, RequestAccountChangePassword, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestActiveTabsUrlUpdate, RequestAuthorizeApprove, RequestAuthorizeReject, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, ResponseAccountExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked } from '../types';
+import type { AccountJson, AllowedPath, MessageTypes, RequestAccountChangePassword, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestActiveTabUrlUpdate, RequestAuthorizeApprove, RequestAuthorizeReject, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, ResponseAccountExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked } from '../types';
 
 import { ALLOWED_PATH, PASSWORD_EXPIRY_MS } from '@polkadot/extension-base/defaults';
 import { isJsonAuthentic, signJson } from '@polkadot/extension-base/utils/accountJsonIntegrity';
@@ -518,7 +518,7 @@ export default class Extension {
     return this.#state.removeAuthRequest(requestId);
   }
 
-  private updateActiveTabUrl ({ url }: RequestActiveTabsUrlUpdate) {
+  private updateActiveTabUrl ({ url }: RequestActiveTabUrlUpdate) {
     this.#state.updateActiveTabUrl(url);
   }
 
@@ -601,7 +601,7 @@ export default class Extension {
         return this.metadataReject(request as RequestMetadataReject, getContentPort).then(respondImmediately);
 
       case 'pri(activeTabUrl.update)':
-        return respondImmediately(this.updateActiveTabUrl(request as RequestActiveTabsUrlUpdate));
+        return respondImmediately(this.updateActiveTabUrl(request as RequestActiveTabUrlUpdate));
 
       case 'pri(connectedTabsUrl.get)':
         return this.getConnectedActiveTabUrl().then(respondImmediately);

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -75,7 +75,7 @@ export interface SigningRequest {
   url: string;
 }
 
-export type ConnectedTabsUrlResponse = string[]
+export type ConnectedTabsUrlResponse = string | undefined
 
 // [MessageType]: [RequestType, ResponseType, SubscriptionMessageType?]
 export interface RequestSignatures {
@@ -98,7 +98,7 @@ export interface RequestSignatures {
   'pri(authorize.delete.request)': [string, void];
   'pri(authorizeDate.update)': [string, void];
   'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void];
-  'pri(activeTabsUrl.update)': [RequestActiveTabsUrlUpdate, void];
+  'pri(activeTabUrl.update)': [RequestActiveTabsUrlUpdate, void];
   'pri(connectedTabsUrl.get)': [null, ConnectedTabsUrlResponse];
   'pri(derivation.create)': [RequestDeriveCreate, boolean];
   'pri(derivation.validate)': [RequestDeriveValidate, ResponseDeriveValidate];
@@ -264,7 +264,7 @@ export interface RequestAccountList {
 export type RequestAccountSubscribe = null;
 
 export interface RequestActiveTabsUrlUpdate {
-  urls: string[];
+  url: string | undefined;
 }
 
 export interface RequestAccountUnsubscribe {

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -98,7 +98,7 @@ export interface RequestSignatures {
   'pri(authorize.delete.request)': [string, void];
   'pri(authorizeDate.update)': [string, void];
   'pri(authorize.update)': [RequestUpdateAuthorizedAccounts, void];
-  'pri(activeTabUrl.update)': [RequestActiveTabsUrlUpdate, void];
+  'pri(activeTabUrl.update)': [RequestActiveTabUrlUpdate, void];
   'pri(connectedTabsUrl.get)': [null, ConnectedTabsUrlResponse];
   'pri(derivation.create)': [RequestDeriveCreate, boolean];
   'pri(derivation.validate)': [RequestDeriveValidate, ResponseDeriveValidate];
@@ -263,7 +263,7 @@ export interface RequestAccountList {
 
 export type RequestAccountSubscribe = null;
 
-export interface RequestActiveTabsUrlUpdate {
+export interface RequestActiveTabUrlUpdate {
   url: string | undefined;
 }
 

--- a/packages/extension-ui/src/Popup/Accounts/index.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/index.tsx
@@ -54,7 +54,7 @@ function Accounts({ className }: Props): React.ReactElement {
   const [filter, setFilter] = useState('');
   const [filteredAccount, setFilteredAccount] = useState<AccountWithChildren[]>([]);
   const [authList, setAuthList] = useState<AuthUrls | null>(null);
-  const [connectedTabsUrl, setConnectedTabsUrl] = useState<string[]>([]);
+  const [connectedActiveTabUrl, setConnectedActiveTabUrl] = useState<string | undefined>();
   const { hierarchy } = useContext(AccountContext);
   const onAction = useContext(ActionContext);
   const networkMap = useMemo(() => getNetworkMap(), []);
@@ -70,7 +70,7 @@ function Accounts({ className }: Props): React.ReactElement {
       .then(({ list }) => setAuthList(list))
       .catch((e) => console.error(e));
     getConnectedTabsUrl()
-      .then((tabsUrl) => setConnectedTabsUrl(tabsUrl))
+      .then(setConnectedActiveTabUrl)
       .catch(console.error);
   }, []);
 
@@ -79,18 +79,18 @@ function Accounts({ className }: Props): React.ReactElement {
       return;
     }
 
-    if (connectedTabsUrl.length > 0) {
+    if (connectedActiveTabUrl) {
       setAccountsCreatedAfterLastAuth(
         flattened.filter(
-          (account) => account?.whenCreated && account?.whenCreated > authList[connectedTabsUrl[0]]?.lastAuth
+          (account) => account?.whenCreated && account?.whenCreated > authList[connectedActiveTabUrl]?.lastAuth
         )
       );
     }
 
-    if (accountsCreatedAfterLastAuth.length > 0) {
-      onAction(`/url/new?url=${connectedTabsUrl[0]}`);
+    if (accountsCreatedAfterLastAuth.length > 0 && connectedActiveTabUrl) {
+      onAction(`/url/new?url=${connectedActiveTabUrl}`);
     }
-  }, [accountsCreatedAfterLastAuth.length, authList, connectedTabsUrl, flattened, onAction]);
+  }, [accountsCreatedAfterLastAuth.length, authList, connectedActiveTabUrl, flattened, onAction]);
 
   useEffect(() => {
     setFilteredAccount(

--- a/packages/extension-ui/src/partials/Header.tsx
+++ b/packages/extension-ui/src/partials/Header.tsx
@@ -3,7 +3,7 @@
 
 import type { ThemeProps } from '../types';
 
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import connectionStatus from '../assets/anim_connection_status.svg';
@@ -45,10 +45,10 @@ function Header({
   withHelp,
   withSettings
 }: Props): React.ReactElement<Props> {
-  const [connectedTabsUrl, setConnectedTabsUrl] = useState<string[]>([]);
+  const [connectedActiveTabUrl, setConnectedActiveTabUrl] = useState<string | undefined>();
   const { t } = useTranslation();
 
-  const isConnected = useMemo(() => connectedTabsUrl.length >= 1, [connectedTabsUrl]);
+  const isConnected = !!connectedActiveTabUrl;
   const onAction = useContext(ActionContext);
 
   useEffect(() => {
@@ -57,7 +57,7 @@ function Header({
     }
 
     getConnectedTabsUrl()
-      .then((tabsUrl) => setConnectedTabsUrl(tabsUrl))
+      .then(setConnectedActiveTabUrl)
       .catch(console.error);
   }, [withConnectedAccounts]);
 
@@ -132,7 +132,7 @@ function Header({
             {isConnected ? (
               <Link
                 className='connectedAccounts'
-                to={connectedTabsUrl.length === 1 ? `/url/manage?url=${connectedTabsUrl[0]}` : '/auth-list'}
+                to={connectedActiveTabUrl ? `/url/manage?url=${connectedActiveTabUrl}` : '/auth-list'}
               >
                 <img
                   className='greenDot'

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -55,15 +55,15 @@ function getActiveTabs () {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     // get the urls of the active tabs. In the case of new tab the url may be empty or undefined
     // we filter these out
-    const urls: string[] = tabs
+    const url = tabs
       .map(({ url }) => url)
-      .filter((url) => !!url) as string[];
+      .filter((url) => !!url)[0];
 
-    const request: TransportRequestMessage<'pri(activeTabsUrl.update)'> = {
+    const request: TransportRequestMessage<'pri(activeTabUrl.update)'> = {
       id: 'background',
-      message: 'pri(activeTabsUrl.update)',
+      message: 'pri(activeTabUrl.update)',
       origin: 'background',
-      request: { urls }
+      request: { url }
     };
 
     const portGetterMock = () => ({


### PR DESCRIPTION
This PR mainly consists of renaming* the unsemantic identifiers not really reflecting their real purpose, which confused me quite a lot until I read the entire flows in the code. This refactor made it much clearer where the problem was.

\* renaming and restructuring a bit on that note: `string[]` -> `string | undefined`

---

FYI for posterity: this is a quick (albeit not dirty) fix for the reported problem. An even more proper fix would include a clean up of the: `selectedAccounts` + `setSelectedAccounts` tightly coupled pair not only doing always the same thing (which means should be encapsulated into a dedicated util, preferably a hook) but also abusing global context for local calulations; as well as the usages of `getAuthList()` along with all other _messages_ using `localStorageStores.authUrls` as they can be easily replaced by direct access to `localStorageStores.authUrls` which would not only reduce loads of code and complexity, but also improve data flow thanks to the ability of subscribing to the auth urls changes, as opposed to the current, regular requests. While I was approaching this solution at first, it started to turn into a very big PR, so I reverted to the bare minimum to solve the actual problem in order not to overload the reviewer borrowed from another team ;) Leaving the option of cleaning the rest up for when @youPickItUp is back.