### PR TITLE
A0-2851: Remove the legal notes from the files created by us

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     // this seems very broken atm, false positives
     '@typescript-eslint/unbound-method': 'off',
     'sort-keys': 'off',
+    'header/header': 'off'
   },
   overrides: [...base.overrides, {
     files: ['**/*.test.*', '**/*.spec.*', '**/*.stories.*'],

--- a/packages/extension-base/src/background/handlers/consts.ts
+++ b/packages/extension-base/src/background/handlers/consts.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const BASE_CREATE_WINDOW_DATA = {
   focused: true,
   width: 376,

--- a/packages/extension-base/src/utils/accountJsonIntegrity.test.ts
+++ b/packages/extension-base/src/utils/accountJsonIntegrity.test.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { isJsonAuthentic, signJson } from './accountJsonIntegrity';
 
 const TEST_ACCOUNT_JSON = {

--- a/packages/extension-base/src/utils/accountJsonIntegrity.ts
+++ b/packages/extension-base/src/utils/accountJsonIntegrity.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import canonicalize from 'canonicalize';
 import { z } from 'zod';
 

--- a/packages/extension-base/src/utils/localStorageStores/commonSchemas.ts
+++ b/packages/extension-base/src/utils/localStorageStores/commonSchemas.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { z } from 'zod';
 
 export const metadata = z.object({

--- a/packages/extension-base/src/utils/localStorageStores/createStoreDefinition.ts
+++ b/packages/extension-base/src/utils/localStorageStores/createStoreDefinition.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-bg authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import deepEquals from 'fast-deep-equal';
 import { z } from 'zod';
 

--- a/packages/extension-base/src/utils/localStorageStores/index.ts
+++ b/packages/extension-base/src/utils/localStorageStores/index.ts
@@ -1,5 +1,2 @@
-// Copyright 2019-2023 @polkadot/extension-bg authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export { default } from './localStorageStores';
 export * from './localStorageStores';

--- a/packages/extension-base/src/utils/localStorageStores/localStorageStores.ts
+++ b/packages/extension-base/src/utils/localStorageStores/localStorageStores.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-bg authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { z } from 'zod';
 
 import * as commonSchemas from './commonSchemas';

--- a/packages/extension-ui/.eslintrc.js
+++ b/packages/extension-ui/.eslintrc.js
@@ -1,6 +1,3 @@
-// Copyright 2017-2023 @polkadot/dev authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 // ordering here important (at least from a rule maintenance pov)
 /* eslint-disable sort-keys */
 
@@ -26,7 +23,8 @@ module.exports = {
     'sort-keys': 'off',
     'react/jsx-no-bind': 'off',
     '@typescript-eslint/no-misused-promises': 'off',
-    '@typescript-eslint/no-floating-promises': 'off'
+    '@typescript-eslint/no-floating-promises': 'off',
+    'header/header': 'off'
   },
   plugins: [...base.plugins, 'prettier'],
   extends: [...base.extends, 'prettier'],

--- a/packages/extension-ui/src/Popup/About.tsx
+++ b/packages/extension-ui/src/Popup/About.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/Popup/Accounts/AddAccountMenu.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/AddAccountMenu.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React from 'react';

--- a/packages/extension-ui/src/Popup/Accounts/ChangePassword.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/ChangePassword.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { FormEvent, useCallback, useContext, useId, useState } from 'react';
 import { useParams } from 'react-router';
 import styled from 'styled-components';

--- a/packages/extension-ui/src/Popup/Accounts/EditAccountMenu.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditAccountMenu.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useContext, useMemo } from 'react';

--- a/packages/extension-ui/src/Popup/Accounts/EditName.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditName.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { FormEvent, useCallback, useContext, useId, useState } from 'react';

--- a/packages/extension-ui/src/Popup/Accounts/EditNetwork.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/EditNetwork.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { FormEvent, useCallback, useContext, useEffect, useId, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import styled from 'styled-components';

--- a/packages/extension-ui/src/Popup/Accounts/NewAccount.tsx
+++ b/packages/extension-ui/src/Popup/Accounts/NewAccount.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/extension-ui/src/Popup/AuthManagement/DisconnectApp.tsx
+++ b/packages/extension-ui/src/Popup/AuthManagement/DisconnectApp.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useContext } from 'react';

--- a/packages/extension-ui/src/Popup/CreateAccount/SafetyFirst.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/SafetyFirst.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/Popup/CreateAccount/SaveMnemonic.tsx
+++ b/packages/extension-ui/src/Popup/CreateAccount/SaveMnemonic.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useState } from 'react';

--- a/packages/extension-ui/src/Popup/ImportSeed/consts.ts
+++ b/packages/extension-ui/src/Popup/ImportSeed/consts.ts
@@ -1,5 +1,2 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const SEED_WORDS_LENGTH = 12;
 export const EMPTY_SEED_WORDS: string[] = new Array<string>(SEED_WORDS_LENGTH).fill('');

--- a/packages/extension-ui/src/Popup/RequestStatus.tsx
+++ b/packages/extension-ui/src/Popup/RequestStatus.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../types';
 
 import React, { useContext, useEffect } from 'react';

--- a/packages/extension-ui/src/Popup/Restore/ImportJsonConfirmStep.tsx
+++ b/packages/extension-ui/src/Popup/Restore/ImportJsonConfirmStep.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ResponseJsonGetAccountInfo } from '@polkadot/extension-base/background/types';
 import type { ThemeProps } from '../../types';
 

--- a/packages/extension-ui/src/Popup/Restore/ImportJsonDropzoneStep.tsx
+++ b/packages/extension-ui/src/Popup/Restore/ImportJsonDropzoneStep.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/Popup/Restore/RestoreJson.tsx
+++ b/packages/extension-ui/src/Popup/Restore/RestoreJson.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ResponseJsonGetAccountInfo } from '@polkadot/extension-base/background/types';
 import type { KeyringPair$Json } from '@polkadot/keyring/types';
 import type { KeyringPairs$Json } from '@polkadot/ui-keyring/types';

--- a/packages/extension-ui/src/Popup/Settings.tsx
+++ b/packages/extension-ui/src/Popup/Settings.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../types';
 
 import React from 'react';

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic/ArgumentValue.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic/ArgumentValue.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic/Extrinsic.stories.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic/Extrinsic.stories.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic/Extrinsic.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic/Extrinsic.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { SignerPayloadJSON } from '@polkadot/types/types';
 
 import React from 'react';

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic/TransactionDetails.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic/TransactionDetails.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import BigNumber from 'bignumber.js';
 import React, { useMemo }  from 'react';
 import styled from 'styled-components';

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic/index.ts
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic/index.ts
@@ -1,5 +1,2 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export { default } from './Extrinsic';
 export * from './Extrinsic';

--- a/packages/extension-ui/src/Popup/Signing/Extrinsic/types.ts
+++ b/packages/extension-ui/src/Popup/Signing/Extrinsic/types.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 /**
  * Any value whose rendering "makes sense" visually. Feel free to expand
  * the union if needed.

--- a/packages/extension-ui/src/Popup/Signing/Tooltip.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Tooltip.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { useCallback, useState } from 'react';

--- a/packages/extension-ui/src/Popup/index.stories.tsx
+++ b/packages/extension-ui/src/Popup/index.stories.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';

--- a/packages/extension-ui/src/components/AddButton.tsx
+++ b/packages/extension-ui/src/components/AddButton.tsx
@@ -1,13 +1,9 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import add from '../assets/add.svg';
 import { ThemeProps } from '../types';
-import Svg from './Svg';
 
 interface Props extends ThemeProps {
   className?: string;

--- a/packages/extension-ui/src/components/AnimatedMessage.tsx
+++ b/packages/extension-ui/src/components/AnimatedMessage.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect, useRef, useState } from 'react';
 import { Transition } from 'react-transition-group';
 import styled from 'styled-components';

--- a/packages/extension-ui/src/components/AnimatedSvg.tsx
+++ b/packages/extension-ui/src/components/AnimatedSvg.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 
 type Props = {

--- a/packages/extension-ui/src/components/BottomWrapper.tsx
+++ b/packages/extension-ui/src/components/BottomWrapper.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/FaviconBox.tsx
+++ b/packages/extension-ui/src/components/FaviconBox.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/FileNameDisplay.tsx
+++ b/packages/extension-ui/src/components/FileNameDisplay.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../types';
 
 import React from 'react';

--- a/packages/extension-ui/src/components/GlobalErrorBoundary.tsx
+++ b/packages/extension-ui/src/components/GlobalErrorBoundary.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributor
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
 import styled from 'styled-components';

--- a/packages/extension-ui/src/components/Header.tsx
+++ b/packages/extension-ui/src/components/Header.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/HelperFooter.tsx
+++ b/packages/extension-ui/src/components/HelperFooter.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../types';
 
 import React from 'react';

--- a/packages/extension-ui/src/components/Hero/Hero.stories.ts
+++ b/packages/extension-ui/src/components/Hero/Hero.stories.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { Meta, StoryObj } from '@storybook/react';
 
 import Hero from './Hero';

--- a/packages/extension-ui/src/components/Hero/Hero.tsx
+++ b/packages/extension-ui/src/components/Hero/Hero.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Hero/index.ts
+++ b/packages/extension-ui/src/components/Hero/index.ts
@@ -1,4 +1,1 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export { default } from './Hero';

--- a/packages/extension-ui/src/components/InputLock.tsx
+++ b/packages/extension-ui/src/components/InputLock.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/LearnMore.tsx
+++ b/packages/extension-ui/src/components/LearnMore.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/packages/extension-ui/src/components/LinksList.tsx
+++ b/packages/extension-ui/src/components/LinksList.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/MenuCard.tsx
+++ b/packages/extension-ui/src/components/MenuCard.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Message.tsx
+++ b/packages/extension-ui/src/components/Message.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Mnemonic/MnemonicInput.stories.tsx
+++ b/packages/extension-ui/src/components/Mnemonic/MnemonicInput.stories.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React, { useState } from 'react';

--- a/packages/extension-ui/src/components/Mnemonic/MnemonicInput.tsx
+++ b/packages/extension-ui/src/components/Mnemonic/MnemonicInput.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useRef } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Mnemonic/MnemonicPill.tsx
+++ b/packages/extension-ui/src/components/Mnemonic/MnemonicPill.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../../types';
 
 import React, { useCallback } from 'react';

--- a/packages/extension-ui/src/components/Mnemonic/index.ts
+++ b/packages/extension-ui/src/components/Mnemonic/index.ts
@@ -1,5 +1,2 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export {default as MnemonicPill} from './MnemonicPill';
 export {default as MnemonicInput} from './MnemonicInput';

--- a/packages/extension-ui/src/components/PasswordField/PasswordFeedback.tsx
+++ b/packages/extension-ui/src/components/PasswordField/PasswordFeedback.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { TransitionGroup } from 'react-transition-group';
 import styled, { useTheme } from 'styled-components';

--- a/packages/extension-ui/src/components/PasswordField/PasswordField.tsx
+++ b/packages/extension-ui/src/components/PasswordField/PasswordField.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/PasswordField/ProgressBar.tsx
+++ b/packages/extension-ui/src/components/PasswordField/ProgressBar.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/PasswordField/getFeedback.ts
+++ b/packages/extension-ui/src/components/PasswordField/getFeedback.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import zxcvbn from 'zxcvbn';
 
 export type ValidationResult = {

--- a/packages/extension-ui/src/components/PasswordField/index.ts
+++ b/packages/extension-ui/src/components/PasswordField/index.ts
@@ -1,4 +1,1 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export {default} from './PasswordField';

--- a/packages/extension-ui/src/components/PasswordField/zxcvbnTranslations.ts
+++ b/packages/extension-ui/src/components/PasswordField/zxcvbnTranslations.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import useTranslation from '../../hooks/useTranslation';
 
 export const useZxcvbnTranslations = () => {

--- a/packages/extension-ui/src/components/PopupBorderContainer.tsx
+++ b/packages/extension-ui/src/components/PopupBorderContainer.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/RadioCard.tsx
+++ b/packages/extension-ui/src/components/RadioCard.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useRef, useState } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/RadioGroup.tsx
+++ b/packages/extension-ui/src/components/RadioGroup.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useState } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/ScrollWrapper.tsx
+++ b/packages/extension-ui/src/components/ScrollWrapper.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Skeleton.tsx
+++ b/packages/extension-ui/src/components/Skeleton.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/SkeletonCard.tsx
+++ b/packages/extension-ui/src/components/SkeletonCard.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/SplashHandler.tsx
+++ b/packages/extension-ui/src/components/SplashHandler.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ReactNode } from 'react';
 import type { ThemeProps } from '@polkadot/extension-ui/types';
 

--- a/packages/extension-ui/src/components/Success.tsx
+++ b/packages/extension-ui/src/components/Success.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Toast/ToastCloseIcon.tsx
+++ b/packages/extension-ui/src/components/Toast/ToastCloseIcon.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import type { ThemeProps } from '../../types';

--- a/packages/extension-ui/src/components/Toast/consts.ts
+++ b/packages/extension-ui/src/components/Toast/consts.ts
@@ -1,4 +1,1 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const TOAST_TIMEOUT = 2500;

--- a/packages/extension-ui/src/components/Toast/iconsList.ts
+++ b/packages/extension-ui/src/components/Toast/iconsList.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export { default as success } from '../../assets/checkmark.svg';
 export { default as critical } from '../../assets/critical.svg';
 export { default as info } from '../../assets/information.svg';

--- a/packages/extension-ui/src/components/Tooltip.tsx
+++ b/packages/extension-ui/src/components/Tooltip.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/Video.tsx
+++ b/packages/extension-ui/src/components/Video.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/components/WarningBox.tsx
+++ b/packages/extension-ui/src/components/WarningBox.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/extension-ui/src/constants.ts
+++ b/packages/extension-ui/src/constants.ts
@@ -1,5 +1,2 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const ALEPH_ZERO_GENESIS_HASH = '0x70255b4d28de0fc4e1a193d7e175ad1ccef431598211c55538f1018651a0344e';
 export const ALEPH_ZERO_TESTNET_GENESIS_HASH = '0x05d5279c52c484cc80396535a316add7d47b1c5b9e0398dd1f584149341460c5';

--- a/packages/extension-ui/src/hooks/useAccountName.ts
+++ b/packages/extension-ui/src/hooks/useAccountName.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useContext } from "react";
 
 import { AccountContext } from "../components";

--- a/packages/extension-ui/src/hooks/useGoTo.ts
+++ b/packages/extension-ui/src/hooks/useGoTo.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback, useContext } from 'react';
 
 import { ActionContext } from '../components/contexts';

--- a/packages/extension-ui/src/hooks/useIsCapsLockOn.ts
+++ b/packages/extension-ui/src/hooks/useIsCapsLockOn.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useState } from "react";
 
 export const useIsCapsLockOn = () => {

--- a/packages/extension-ui/src/hooks/useRequestsPagination.ts
+++ b/packages/extension-ui/src/hooks/useRequestsPagination.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useEffect, useState } from 'react';
 
 const getSafeIndex = (index: number, arrLength: number) => Math.min(index, Math.max(arrLength - 1, 0));

--- a/packages/extension-ui/src/links.ts
+++ b/packages/extension-ui/src/links.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const LINKS = {
   MAIN_WEBSITE: 'https://alephzero.org/',
   GENERAL_INTRODUCTION: 'https://docs.alephzero.org/aleph-zero/aleph-zero-signer/general-introduction',

--- a/packages/extension-ui/src/partials/NewAccountSelection.tsx
+++ b/packages/extension-ui/src/partials/NewAccountSelection.tsx
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { ThemeProps } from '../types';
 
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';

--- a/packages/extension-ui/src/types/styled.d.ts
+++ b/packages/extension-ui/src/types/styled.d.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import 'styled-components';
 
 import type { Theme } from '../types';

--- a/packages/extension-ui/src/util/createGroupedAccountData.ts
+++ b/packages/extension-ui/src/util/createGroupedAccountData.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { AccountJson, AccountWithChildren } from '@polkadot/extension-base/background/types';
 import getNetworkMap from '@polkadot/extension-ui/util/getNetworkMap';
 

--- a/packages/extension-ui/src/util/ellipsisName.ts
+++ b/packages/extension-ui/src/util/ellipsisName.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const ellipsisName = (input: string | null | undefined): string | null => {
   if (!input || input.length < 8) {
     return null;

--- a/packages/extension-ui/src/util/getFaviconUrl.ts
+++ b/packages/extension-ui/src/util/getFaviconUrl.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export async function getFaviconUrl(url: string): Promise<string> {
   const defaultPath = '/favicon.ico';
   const { origin } = new URL(url);

--- a/packages/extension-ui/src/util/keyDownWrappers.ts
+++ b/packages/extension-ui/src/util/keyDownWrappers.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { KeyboardEvent } from 'react';
 
 const triggerOnCodes = <T>(

--- a/packages/extension-ui/src/util/recodeAddress.ts
+++ b/packages/extension-ui/src/util/recodeAddress.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { AccountJson, AccountWithChildren } from '@polkadot/extension-base/background/types';
 import type { Chain } from '@polkadot/extension-chains/types';
 import type { SettingsStruct } from '@polkadot/ui-settings/types';

--- a/packages/extension-ui/src/zindex.ts
+++ b/packages/extension-ui/src/zindex.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export const Z_INDEX = {
   ADDRESS: 1,
   ADD_ACCOUNT_BACKGROUND: -100,

--- a/packages/extension/src/listenOnPort.ts
+++ b/packages/extension/src/listenOnPort.ts
@@ -1,6 +1,3 @@
-// Copyright 2019-2023 @polkadot/extension authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { PORT_CONTENT, PORT_EXTENSION } from '@polkadot/extension-base/defaults';
 
 /**


### PR DESCRIPTION
<img width="489" alt="image" src="https://github.com/Cardinal-Cryptography/aleph-zero-signer/assets/6209244/8419a8d7-00ea-46d3-8f46-8d21488211b7">


Btw at the same time we're leaving the legal notes in the files created by Polkadot.