### PR TITLE
A0-2943: Enhance the script adapting build to FF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ cc-test-reporter
 lerna-debug.log*
 extension-chrome.zip
 extension-firefox.zip
-master-src.zip
+source-code.zip
 npm-debug.log*
 tsconfig.*buildinfo
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "packages/*"
   ],
   "scripts": {
-    "adapt-build-to-ff": "jq '.background.scripts = [.background.service_worker] | del(.background.service_worker)' packages/extension/build/manifest.json > tmp.$$.json && mv tmp.$$.json packages/extension/build/manifest.json",
+    "adapt-build-to-ff": "ts-node --esm scripts/adaptBuildToFf.mts",
     "build": "yarn download-chains-metadata && polkadot-dev-build-ts && yarn build:zip && yarn build:rollup",
     "build-storybook": "storybook build",
     "build:extra": "yarn build:i18n && yarn build:ui",
@@ -31,7 +31,7 @@
     "build:zip": "yarn build:zip:dst:chrome && yarn adapt-build-to-ff && yarn build:zip:dst:firefox && yarn build:zip:src",
     "build:zip:dst:chrome": "rm -rf ./extension-chrome.zip && cd packages/extension/build && zip -r -FS ../../../extension-chrome.zip .",
     "build:zip:dst:firefox": "rm -rf ./extension-firefox.zip && cd packages/extension/build && zip -r -FS ../../../extension-firefox.zip .",
-    "build:zip:src": "rm -rf ./master-src.zip && zip -r -x '*build/*' -x '*node_modules*' -FS ./master-src.zip packages .editorconfig .eslintignore .eslintrc.js babel.config.cjs CHANGELOG.md CONTRIBUTING.md i18next-scanner.config.js jest.config.cjs LICENSE package.json README.md tsconfig.json yarn.lock",
+    "build:zip:src": "rm -rf ./source-code.zip && zip -r -x '*build/*' -x '*node_modules*' -FS ./source-code.zip packages .editorconfig .eslintignore .eslintrc.js babel.config.cjs CHANGELOG.md CONTRIBUTING.md i18next-scanner.config.js jest.config.cjs LICENSE package.json README.md tsconfig.json tsconfig.base.json tsconfig.build.json rollup.config.mjs yarn.lock .yarn/patches .yarn/plugins .yarn/releases scripts",
     "clean": "polkadot-dev-clean-build",
     "download-chains-metadata": "ts-node --esm scripts/downloadMetadata.mts",
     "lint": "polkadot-dev-run-lint",

--- a/scripts/adaptBuildToFf.mts
+++ b/scripts/adaptBuildToFf.mts
@@ -1,0 +1,25 @@
+import fs from 'fs/promises';
+
+const BUILT_MANIFEST_PATH = './packages/extension/build/manifest.json';
+
+fs.readFile(BUILT_MANIFEST_PATH, 'utf8').then(chromeContent => {
+  const { background: { service_worker, ...background }, ...json } = JSON.parse(chromeContent)
+
+  const ffJson = {
+    ...json,
+    background: {
+      scripts: [service_worker],
+      ...background,
+    },
+    browser_specific_settings: {
+      gecko: {
+        id: 'signer-webextension@alephzero.org',
+        strict_min_version: '109.0'
+      }
+    }
+  }
+
+  const ffContent = JSON.stringify(ffJson, undefined, 2)
+
+  return fs.writeFile(BUILT_MANIFEST_PATH, ffContent)
+})


### PR DESCRIPTION
The FF report about bundle problems showed that the build process on their machine failed on the missing `jq` command. Since this command is used to adapt the chrome build to ff, the chrome build had managed to be successful at that point. This means that even though the overal build process failed, the chrome zip was present, so they musth have thought it's the zip they were looking for and it must have been the one they analyzed, which lead to the obesrvations that the manifest* contents mismatched with the zip created by us.

This PR replaces usage of the `jq` command with a regular TS script, more suitable than a mere cli command since we're also adding the `browser_specific_settings` key (which we manually added to the previous zip sent to the web store) so it's getting too complex for a mere cli command. I'm also adapting the source-code-zipping script that apparently had not been used for a longer time, but now it'll come useful for us due to the ff requirement of providing them the zipped source code.

---

<details><summary>*</summary>
Actualy there's one more difference that can occur between the bundles created on different machines - it's the absolute filepath present in the bundles.

![image](https://github.com/Cardinal-Cryptography/aleph-zero-signer/assets/6209244/c8aa2b40-1d37-4151-b355-090f57004784)
<img width="1401" alt="image" src="https://github.com/Cardinal-Cryptography/aleph-zero-signer/assets/6209244/c432d626-d7ff-4cb2-bd44-16062330b3d4">

This is much harder to get rid of, because a reference to this is present in loads of polkadot dependencies:
![image](https://github.com/Cardinal-Cryptography/aleph-zero-signer/assets/6209244/a32572cc-9793-4af3-8220-9d62b445411a)

so getting rid of it would require yarn-patcking all of those packes - that's a really hefty _hack_.

The built bundles present far less occurences of those tricky file paths than those search occurences in packages, so of course we could try pinpointing and fixing only those couple ones, but this would really be a _hack on a hack_: very nasty, with potential of re-surfacing itself in the future in least expected moments in which we'd be back in square one of this problem. My conclusion is then: let's hope the ff web store doesn't mind those discrepancies and it doesn't need fixing at all ;) :P

Note also that if we're worried about including our personal machines paths in the bundles - this will not be a case after we move to publishing from CI.
</details>