### PR TITLE
A0-2946: Seed phrase input should not allow for upper case

### DIFF
--- a/packages/extension-ui/src/Popup/ImportSeed/SeedAndPath.tsx
+++ b/packages/extension-ui/src/Popup/ImportSeed/SeedAndPath.tsx
@@ -119,7 +119,7 @@ function SeedAndPath({ className, genesis, onAccountChange, onNextStep, type }: 
       return;
     }
 
-    const seed = seedWords.join(' ');
+    const seed = seedWords.join(' ').toLowerCase();
     const suri = seed + path;
 
     validateSeed(suri, type)
@@ -207,7 +207,7 @@ function SeedAndPath({ className, genesis, onAccountChange, onNextStep, type }: 
           title={t<string>('Enter your 12-word secret phrase')}
         />
         <MnemonicWrapper>
-          <MnemonicInput
+          <StyledMnemonicInput
             onChange={onSeedWordsChange}
             seedWords={seedWords}
             showError={!!error}
@@ -271,6 +271,12 @@ const MnemonicWrapper = styled.div`
 
   & > :last-child:not(:only-child) {
     margin-bottom: 8px;
+  }
+`;
+
+const StyledMnemonicInput = styled(MnemonicInput)`
+  input {
+    text-transform: lowercase;
   }
 `;
 

--- a/packages/extension-ui/src/Popup/ImportSeed/SeedAndPath.tsx
+++ b/packages/extension-ui/src/Popup/ImportSeed/SeedAndPath.tsx
@@ -262,12 +262,15 @@ const StyledHeader = styled(Header)`
 `;
 
 const MnemonicWrapper = styled.div`
-  &&& > * {
+  display: flow-root;
+  margin-bottom: 8px;
+
+  & > * {
     margin-bottom: 16px;
   }
 
-  && > :only-child {
-    margin-bottom: 24px;
+  & > :last-child:not(:only-child) {
+    margin-bottom: 8px;
   }
 `;
 

--- a/packages/extension-ui/src/components/Mnemonic/MnemonicPill.tsx
+++ b/packages/extension-ui/src/components/Mnemonic/MnemonicPill.tsx
@@ -28,6 +28,7 @@ const MnemonicPill = ({ className, index, inputRef, name, onChange, onKeyDown, w
     <div className={className}>
       <div className='mnemonic-index'>{index + 1}</div>
       <input
+        autoCapitalize='off'
         name={name}
         onChange={_handleChange}
         onKeyDown={onKeyDown}


### PR DESCRIPTION
The solution is a bit hacky - I style input to show all letter as lowercase and I allow uppercase letters, even store them in state, and only when validating / calculating account properties I change them to lowercase. This way I don't change the value passed to input, which resets the cursor position.

This fixes an edge case, where user inputs an uppercase letter in the middle of input value, I change it to lowercase, but since the  input value changed the cursor gets reset and placed at the end of the input value, causing an excruciating pain to overzealous tester :see_no_evil: 