### PR TITLE
A0-3946: Fix password saving function not working properly

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.spec.ts
+++ b/packages/extension-base/src/background/handlers/Extension.spec.ts
@@ -33,6 +33,11 @@ const authUrls = {
 
 chromeStub.windows.getAll.resolves([]);
 
+// @ts-expect-error the "sinon-chrome" mocking library does not provide stubs for session storage, so we have to append them ourselves
+chromeStub.storage.session = {
+  get: () => Promise.resolve({})
+};
+
 const stubChromeStorage = (data: Record<string, unknown> = {}) => chromeStub.storage.local.get.resolves({
   authUrls,
   ...data

--- a/packages/extension-base/src/background/handlers/chromeStorage.ts
+++ b/packages/extension-base/src/background/handlers/chromeStorage.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+// use namespaces to add typization for your storage data
+const namespaces = { 'password-cache': z.record(z.string(), z.object({ password: z.string(), expiresAt: z.number() })) } as const satisfies Record<string, z.ZodSchema>;
+
+export const setItem = async <N extends keyof typeof namespaces>(namespace: N, updater: (currData?: z.TypeOf<typeof namespaces[N]>) => z.TypeOf<typeof namespaces[N]>) => {
+  const currentData = await getItem(namespace);
+
+  await chrome.storage.session.set({ [namespace]: updater(currentData) });
+};
+
+export const getItem = async <N extends keyof typeof namespaces>(namespace: N): Promise<z.infer<typeof namespaces[N]> | undefined> => {
+  const { [namespace]: cachedData } = await chrome.storage.session.get(namespace);
+
+  try {
+    return namespaces[namespace].parse(cachedData);
+  } catch {
+    return undefined;
+  }
+};
+
+export const removeItem = async <N extends keyof typeof namespaces>(namespace: N) => {
+  await chrome.storage.session.remove(namespace);
+};
+
+const chromeStorage = {
+  getItem,
+  setItem,
+  removeItem
+};
+
+export default chromeStorage;

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -306,8 +306,8 @@ export interface RequestSigningIsLocked {
 }
 
 export interface ResponseSigningIsLocked {
-  isLocked: boolean;
   remainingTime: number;
+  isLocked: boolean;
 }
 
 export type RequestSigningSubscribe = null;

--- a/packages/extension-ui/src/Popup/Signing/Request/SignArea.tsx
+++ b/packages/extension-ui/src/Popup/Signing/Request/SignArea.tsx
@@ -45,7 +45,9 @@ function SignArea({ buttonText, className, error, isExternal, isFirst, isLast, s
 
           // if the account was unlocked check the remember me
           // automatically to prolong the unlock period
-          !isLocked && setSavePass(true);
+          if(remainingTime > 0) {
+            setSavePass(true);
+          }
         })
         .catch((error: Error) => console.error(error));
 
@@ -92,20 +94,15 @@ function SignArea({ buttonText, className, error, isExternal, isFirst, isLast, s
 
   const StyledCheckbox = styled(Checkbox)`
     margin-left: 8px;
-`;
+  `;
 
   const RememberPasswordCheckbox = () => (
     <StyledCheckbox
       checked={savePass}
-      label={
-        isLocked
-          ? t<string>('Remember password for {{expiration}} minutes', {
-              replace: { expiration: PASSWORD_EXPIRY_MIN }
-            })
-          : t<string>('Extend the period without password by {{expiration}} minutes', {
-              replace: { expiration: PASSWORD_EXPIRY_MIN }
-            })
-      }
+      disabled={!isLocked}
+      label={t<string>('Remember password for {{expiration}} minutes', {
+        replace: { expiration: PASSWORD_EXPIRY_MIN }
+      })}
       onChange={setSavePass}
     />
   );

--- a/packages/extension-ui/src/components/Checkbox.tsx
+++ b/packages/extension-ui/src/components/Checkbox.tsx
@@ -9,6 +9,7 @@ import Subtract from '../assets/subtract.svg';
 
 interface Props {
   checked: boolean;
+  disabled?: boolean;
   indeterminate?: boolean;
   className?: string;
   label: ReactNode;
@@ -20,6 +21,7 @@ interface Props {
 function Checkbox({
   checked,
   className,
+  disabled,
   indeterminate,
   label,
   onChange,
@@ -49,6 +51,7 @@ function Checkbox({
         {label}
         <input
           checked={checked && !indeterminate}
+          disabled={disabled}
           onBlur={() => setIsFocusVisible(false)}
           onChange={_onChange}
           onClick={_onClick}
@@ -102,7 +105,7 @@ const Label = styled.label<{ isOutlined: boolean; variant: NonNullable<Props['va
     cursor: pointer;
     user-select: none;
     padding-left: ${({ variant }) => variantToStyles[variant].paddingLeft};;
-    padding-top: 1px;
+    padding-top: 2px;
     color: ${({ theme }) => theme.subTextColor};
     font-size: ${({ theme }) => theme.fontSize};
     line-height: ${({ theme }) => theme.lineHeight};
@@ -113,6 +116,10 @@ const Label = styled.label<{ isOutlined: boolean; variant: NonNullable<Props['va
 
     :has(input:focus-visible) {
       outline-style: auto;
+    }
+
+    :has(input:disabled) {
+      color: ${({ theme }) => theme.disabledTextColor}
     }
 
     /* :has selector is the pure css solution to this problem, but doesn't have (so far) enough support ;( */
@@ -186,6 +193,15 @@ export default styled(Checkbox)(
         top: 2px;
         mask: url(${Subtract});
         mask-size: cover;
+      }
+    }
+
+    input:disabled ~ .checkbox-ui {
+      background: ${theme.disabledTextColor};
+      box-shadow: 0 0 0 1px ${theme.disabledTextColor};
+
+      &:hover {
+        box-shadow: 0 0 0 1px ${theme.disabledTextColor};
       }
     }
   }


### PR DESCRIPTION
Issue 1: Password saving feature was not consistent. ✅ 
Issue 2: If checkbox "Extend the period without password by 15 minutes" was not checked, it locks account and on next sign in asks for password, even if saved password was still in the memory and it didn't expire yet. ✅ 

Tested in Chrome and FF.

P.S. I edited some code but were not able to test them yet, since nightly wallet was not responding. I will test it again in the morning.