### PR TITLE
A0-2999: Run on workflows on node20

### DIFF
--- a/.github/workflows/gnerate-extension-bundles.yml
+++ b/.github/workflows/gnerate-extension-bundles.yml
@@ -11,10 +11,10 @@ jobs:
     name: Generate extension bundles
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js version from .nvmrc
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -28,7 +28,7 @@ jobs:
       - run: yarn polkadot-dev-build-ts
       - run: yarn build:zip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: signer-extension-bundles-v${{ github.ref_name }}
           retention-days: 30

--- a/.github/workflows/pr-any.yml
+++ b/.github/workflows/pr-any.yml
@@ -9,10 +9,10 @@ jobs:
     name: ${{ matrix.step }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js version from .nvmrc
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: yarn


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.